### PR TITLE
Use Yomihon as translator in Android.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -146,6 +146,10 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <data android:mimeType="text/plain" />
             </intent-filter>
+            <intent-filter android:label="@string/app_name">
+                <action android:name="android.intent.action.TRANSLATE" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
             <intent-filter android:label="@string/app_settings">
                 <action android:name="android.intent.action.APPLICATION_PREFERENCES" />
                 <category android:name="android.intent.category.DEFAULT" />

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/dictionary/DictionaryTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/dictionary/DictionaryTab.kt
@@ -21,7 +21,10 @@ import eu.kanade.presentation.dictionary.DictionarySearchScreen
 import eu.kanade.presentation.util.Tab
 import eu.kanade.tachiyomi.ui.main.MainActivity
 import eu.kanade.tachiyomi.ui.setting.SettingsScreen
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.receiveAsFlow
 import tachiyomi.i18n.MR
 import tachiyomi.presentation.core.i18n.stringResource
 
@@ -104,5 +107,18 @@ data object DictionaryTab : Tab {
         LaunchedEffect(Unit) {
             (context as? MainActivity)?.ready = true
         }
+
+        LaunchedEffect(Unit) {
+            queryEvent.receiveAsFlow().collectLatest { query ->
+                // Wait until dictionaries are loaded so the search can find enabled ones
+                screenModel.state.first { !it.isLoading }
+                screenModel.updateQuery(query)
+                screenModel.search(query)
+            }
+        }
     }
+
+    // For invoking search from other screens
+    private val queryEvent = Channel<String>()
+    suspend fun search(query: String) = queryEvent.send(query)
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/home/HomeScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/home/HomeScreen.kt
@@ -164,7 +164,7 @@ object HomeScreen : Screen() {
                                 }
                                 BrowseTab
                             }
-                            Tab.Dictionary -> DictionaryTab
+                            is Tab.Dictionary -> DictionaryTab
                             is Tab.More -> MoreTab
                         }
 
@@ -173,6 +173,9 @@ object HomeScreen : Screen() {
                         }
                         if (it is Tab.More && it.toDownloads) {
                             navigator.push(DownloadQueueScreen)
+                        }
+                        if (it is Tab.Dictionary) {
+                            it.initialQuery?.let { query -> DictionaryTab.search(query) }
                         }
                     }
                 }
@@ -310,7 +313,7 @@ object HomeScreen : Screen() {
         data object Updates : Tab
         data object History : Tab
         data class Browse(val toExtensions: Boolean = false) : Tab
-        data object Dictionary : Tab
+        data class Dictionary(val initialQuery: String? = null) : Tab
         data class More(val toDownloads: Boolean) : Tab
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivity.kt
@@ -563,6 +563,16 @@ class MainActivity : BaseActivity() {
                 }
                 null
             }
+            Intent.ACTION_TRANSLATE -> {
+                // System "translate" action: look the text up in the dictionary tab
+                val text = intent.getStringExtra(Intent.EXTRA_TEXT)
+                if (text.isNullOrBlank()) {
+                    null
+                } else {
+                    navigator.popUntilRoot()
+                    HomeScreen.Tab.Dictionary(initialQuery = text)
+                }
+            }
             Intent.ACTION_VIEW -> {
                 // Handling opening of backup files
                 if (intent.data.toString().endsWith(".tachibk")) {


### PR DESCRIPTION
This PR lets you use Yomihon as a translator in Android. I.e., you select text in any app and in the context menu choose translate and select Yomihon there. It will open the selected text in Yomihon's dictionary and thanks to the awesomeness of the dictionary tab you can click through the words to check their translations/dictionary definitions.

I understand that Yomihon is neither a translator nor is it a general dictionary app, but this is a feature that is so simple to add and helps me immensely, as I always wanted a Yomitan dictionary lookup from other apps, not just in the browser on Android!